### PR TITLE
Patch for digital ocean api change and ram bump

### DIFF
--- a/doapi.js
+++ b/doapi.js
@@ -38,7 +38,7 @@ api = function(key){
 		var data = {
 			resources: [
 				{
-					resource_id: ""+dropletID,
+					resource_id: '' + dropletID,
 					resource_type: 'droplet'
 				}
 			]
@@ -61,7 +61,7 @@ api = function(key){
 		var data = {
 			name: args.name, // || return false,
 			region: args.region || 'nyc3',
-			size: args.size || '512mb',
+			size: args.size || 's-1vcpu-1gb',
 			image: args.image || 'ubuntu-14-04-x64',
 			ssh_keys: args.ssh_key || null,
 			backups: args.backup || false,

--- a/doapi.js
+++ b/doapi.js
@@ -38,7 +38,7 @@ api = function(key){
 		var data = {
 			resources: [
 				{
-					resource_id: dropletID,
+					resource_id: ""+dropletID,
 					resource_type: 'droplet'
 				}
 			]

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www"
+    "start": "node ./bin/www",
+    "test": "node ./testAPI.js"
   },
   "dependencies": {
     "body-parser": "~1.13.2",

--- a/routes/workers.json
+++ b/routes/workers.json
@@ -2,7 +2,7 @@
 	"image":"25092187",
 	"version":10,
 	"lastSnapShotId":"23505298",
-	"size":"512mb",
+	"size":"s-1vcpu-1gb",
 	"max":100,
 	"min":3,
 	"minAvail":3

--- a/testAPI.js
+++ b/testAPI.js
@@ -21,7 +21,8 @@ var callRunner = (function(){
 
 			
 			let httpOptions = {
-				url: 'http://codeland.bytedev.co:2000/api/run?once=true',
+				url: "http://localhost:2000/api/run?once=true",
+				// url: 'http://codeland.bytedev.co:2000/api/run?once=true',
 				form: {
 					code: code || `python3 -c "
 from time import sleep
@@ -37,6 +38,7 @@ sleep(${sleepTime})
 					noRunner++;
 				}else if(error || response.statusCode !== 200){
 					errors++;
+				} else {
 					body = JSON.parse(body);
 					res = (Buffer.from(body.res, 'base64').toString('ascii'));
 				}
@@ -58,4 +60,4 @@ let __do = function(till){
 	setTimeout(__do, 1500, --till);
 };
 
-__do(30)
+__do(1000)


### PR DESCRIPTION
digital ocean has made the tags endpoint official and would now like a string to identify the resource being tagged. I must assume that this means there are resources that are not numbers as the identifiers for droplets are(or maybe they prefer strings). They have also kindly upgraded the ram on $5 droplets to allow for 1 gb of ram(how nice of them).
- updated droplet tagging to send resource_id as a string.
- updated all *defaults* for droplet ram size to 1gb